### PR TITLE
Implement comprehensive IOStat parser and reporter with enhanced charts

### DIFF
--- a/internal/reporters/iostat_html_report.go
+++ b/internal/reporters/iostat_html_report.go
@@ -1,0 +1,843 @@
+//	Copyright 2023 Dremio Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporters
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GenerateIOStatHTML generates a self-contained HTML report with three charts:
+// 1. CPU Utilization Over Time
+// 2. Device I/O Throughput Over Time
+// 3. Device Utilization Over Time
+func GenerateIOStatHTML(data *IOStatReportData) (string, error) {
+	if data == nil || len(data.Snapshots) == 0 {
+		return generateEmptyIOStatHTML(), nil
+	}
+
+	// Prepare data for charts
+	labels := extractIOStatTimeLabels(data)
+	cpuData := extractCPUSeriesData(data)
+	ioThroughputData := extractIOThroughputSeriesData(data)
+
+	// Generate HTML with embedded charts
+	html := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IOStat Analysis Report</title>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            background-color: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .header {
+            background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%);
+            color: white;
+            padding: 30px;
+            text-align: center;
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 2.5em;
+            font-weight: 300;
+        }
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            padding: 30px;
+            background-color: #f8f9fa;
+        }
+        .stat-card {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .stat-value {
+            font-size: 2em;
+            font-weight: bold;
+            color: #667eea;
+            margin-bottom: 5px;
+        }
+        .stat-label {
+            color: #666;
+            font-size: 0.9em;
+        }
+        .chart-container {
+            padding: 30px;
+            border-bottom: 1px solid #eee;
+        }
+        .chart-container:last-child {
+            border-bottom: none;
+        }
+        .chart-title {
+            font-size: 1.5em;
+            margin-bottom: 20px;
+            color: #333;
+            text-align: center;
+        }
+        .chart {
+            width: 100%%;
+            height: 400px;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>IOStat Analysis Report</h1>
+            <p>System I/O Performance Analysis</p>
+        </div>
+        
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div class="stat-value">%d</div>
+                <div class="stat-label">Snapshots</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">%d</div>
+                <div class="stat-label">Devices Monitored</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">%.1f%%</div>
+                <div class="stat-label">Peak CPU Usage</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">%.1f</div>
+                <div class="stat-label">Peak Device Avg. Queue Size</div>
+            </div>
+        </div>
+
+        <div class="chart-container">
+            <div class="chart-title">CPU Utilization Over Time</div>
+            <div id="cpuChart" class="chart"></div>
+        </div>
+
+        <div class="chart-container">
+            <div class="chart-title">Device I/O Throughput Over Time</div>
+            <div id="ioThroughputChart" class="chart"></div>
+        </div>
+
+
+
+        <div class="chart-container">
+            <div class="chart-title">Device I/O Await Times</div>
+            <div id="deviceAwaitChart" class="chart"></div>
+        </div>
+
+        <div class="chart-container">
+            <div class="chart-title">Device Average Queue Size</div>
+            <div id="deviceQueueChart" class="chart"></div>
+        </div>
+
+        <div class="chart-container">
+            <div class="chart-title">Device I/O Requests Per Second</div>
+            <div id="deviceRequestsChart" class="chart"></div>
+        </div>
+
+        <div class="chart-container">
+            <div class="chart-title">Device I/O Request Sizes</div>
+            <div id="deviceRequestSizeChart" class="chart"></div>
+        </div>
+
+
+    </div>
+
+    <script>
+        try {
+            // CPU Utilization Chart
+            const cpuChart = echarts.init(document.getElementById('cpuChart'));
+            const cpuOption = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross'
+                    }
+                },
+                legend: {
+                    data: ['User', 'System', 'IOWait', 'Idle']
+                },
+                grid: {
+                    left: '3%%',
+                    right: '4%%',
+                    bottom: '3%%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: %s
+                },
+                yAxis: {
+                    type: 'value',
+                    name: 'CPU %%',
+                    min: 0,
+                    max: 100
+                },
+                series: %s
+            };
+            cpuChart.setOption(cpuOption);
+
+            // I/O Throughput Chart
+            const ioThroughputChart = echarts.init(document.getElementById('ioThroughputChart'));
+            const ioThroughputOption = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross'
+                    }
+                },
+                legend: {
+                    data: ['Read KB/s', 'Write KB/s']
+                },
+                grid: {
+                    left: '3%%',
+                    right: '4%%',
+                    bottom: '3%%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: %s
+                },
+                yAxis: {
+                    type: 'value',
+                    name: 'KB/s'
+                },
+                series: %s
+            };
+            ioThroughputChart.setOption(ioThroughputOption);
+
+
+
+            // Device I/O Await Chart
+            const deviceAwaitChart = echarts.init(document.getElementById('deviceAwaitChart'));
+            const deviceAwaitOption = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross'
+                    }
+                },
+                legend: {
+                    data: %s
+                },
+                grid: {
+                    left: '3%%',
+                    right: '4%%',
+                    bottom: '3%%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: %s
+                },
+                yAxis: {
+                    type: 'value',
+                    name: 'Await Time (ms)'
+                },
+                series: %s
+            };
+            deviceAwaitChart.setOption(deviceAwaitOption);
+
+            // Device Queue Size Chart
+            const deviceQueueChart = echarts.init(document.getElementById('deviceQueueChart'));
+            const deviceQueueOption = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross'
+                    }
+                },
+                legend: {
+                    data: %s
+                },
+                grid: {
+                    left: '3%%',
+                    right: '4%%',
+                    bottom: '3%%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: %s
+                },
+                yAxis: {
+                    type: 'value',
+                    name: 'Queue Size'
+                },
+                series: %s
+            };
+            deviceQueueChart.setOption(deviceQueueOption);
+
+            // Device Requests Chart
+            const deviceRequestsChart = echarts.init(document.getElementById('deviceRequestsChart'));
+            const deviceRequestsOption = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross'
+                    }
+                },
+                legend: {
+                    data: %s
+                },
+                grid: {
+                    left: '3%%',
+                    right: '4%%',
+                    bottom: '3%%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: %s
+                },
+                yAxis: {
+                    type: 'value',
+                    name: 'Requests/sec'
+                },
+                series: %s
+            };
+            deviceRequestsChart.setOption(deviceRequestsOption);
+
+            // Device Request Size Chart
+            const deviceRequestSizeChart = echarts.init(document.getElementById('deviceRequestSizeChart'));
+            const deviceRequestSizeOption = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross'
+                    }
+                },
+                legend: {
+                    data: %s
+                },
+                grid: {
+                    left: '3%%',
+                    right: '4%%',
+                    bottom: '3%%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: %s
+                },
+                yAxis: {
+                    type: 'value',
+                    name: 'Request Size (KB)'
+                },
+                series: %s
+            };
+            deviceRequestSizeChart.setOption(deviceRequestSizeOption);
+
+            // Handle window resize
+            window.addEventListener('resize', function() {
+                cpuChart.resize();
+                ioThroughputChart.resize();
+                deviceAwaitChart.resize();
+                deviceQueueChart.resize();
+                deviceRequestsChart.resize();
+                deviceRequestSizeChart.resize();
+            });
+
+        } catch (error) {
+            console.error('Error initializing charts:', error);
+            document.body.innerHTML += '<div style="color: red; padding: 20px; background: #ffe6e6; border: 1px solid red; margin: 20px;">Error initializing charts: ' + error.message + '</div>';
+        }
+    </script>
+</body>
+</html>`,
+		len(data.Snapshots),
+		countUniqueDevices(data),
+		findPeakCPUUsage(data),
+		findPeakDeviceQueueSize(data),
+		labels,
+		cpuData,
+		labels,
+		ioThroughputData,
+		extractDeviceAwaitLegendData(data),
+		labels,
+		extractDeviceAwaitSeriesData(data),
+		extractDeviceQueueLegendData(data),
+		labels,
+		extractDeviceQueueSeriesData(data),
+		extractDeviceRequestsLegendData(data),
+		labels,
+		extractDeviceRequestsSeriesData(data),
+		extractDeviceRequestSizeLegendData(data),
+		labels,
+		extractDeviceRequestSizeSeriesData(data))
+
+	return html, nil
+}
+
+// generateEmptyIOStatHTML generates HTML for empty iostat data
+func generateEmptyIOStatHTML() string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IOStat Analysis Report</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+        .empty-state {
+            text-align: center;
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .empty-state h1 {
+            color: #666;
+            margin-bottom: 10px;
+        }
+        .empty-state p {
+            color: #999;
+        }
+    </style>
+</head>
+<body>
+    <div class="empty-state">
+        <h1>No IOStat Data Available</h1>
+        <p>The iostat file appears to be empty or could not be parsed.</p>
+    </div>
+</body>
+</html>`
+}
+
+// extractIOStatTimeLabels extracts time labels for chart x-axis
+func extractIOStatTimeLabels(data *IOStatReportData) string {
+	var labels []string
+	for _, snapshot := range data.Snapshots {
+		labels = append(labels, fmt.Sprintf(`"%s"`, snapshot.Timestamp.Format("15:04:05")))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(labels, ", "))
+}
+
+// extractCPUSeriesData extracts CPU utilization data for charts
+func extractCPUSeriesData(data *IOStatReportData) string {
+	userData := make([]string, len(data.Snapshots))
+	systemData := make([]string, len(data.Snapshots))
+	iowaitData := make([]string, len(data.Snapshots))
+	idleData := make([]string, len(data.Snapshots))
+
+	for i, snapshot := range data.Snapshots {
+		if snapshot.CPUStats != nil {
+			userData[i] = fmt.Sprintf("%.1f", snapshot.CPUStats.User)
+			systemData[i] = fmt.Sprintf("%.1f", snapshot.CPUStats.System)
+			iowaitData[i] = fmt.Sprintf("%.1f", snapshot.CPUStats.IOWait)
+			idleData[i] = fmt.Sprintf("%.1f", snapshot.CPUStats.Idle)
+		} else {
+			userData[i] = "0"
+			systemData[i] = "0"
+			iowaitData[i] = "0"
+			idleData[i] = "0"
+		}
+	}
+
+	series := []string{
+		fmt.Sprintf(`{
+			name: "User",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, strings.Join(userData, ", ")),
+		fmt.Sprintf(`{
+			name: "System",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, strings.Join(systemData, ", ")),
+		fmt.Sprintf(`{
+			name: "IOWait",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, strings.Join(iowaitData, ", ")),
+		fmt.Sprintf(`{
+			name: "Idle",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, strings.Join(idleData, ", ")),
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(series, ", "))
+}
+
+// extractIOThroughputSeriesData extracts I/O throughput data for charts
+func extractIOThroughputSeriesData(data *IOStatReportData) string {
+	// Aggregate read and write throughput across all devices
+	readData := make([]string, len(data.Snapshots))
+	writeData := make([]string, len(data.Snapshots))
+
+	for i, snapshot := range data.Snapshots {
+		totalRead := 0.0
+		totalWrite := 0.0
+
+		for _, device := range snapshot.Devices {
+			totalRead += device.ReadKBPerS
+			totalWrite += device.WriteKBPerS
+		}
+
+		readData[i] = fmt.Sprintf("%.1f", totalRead)
+		writeData[i] = fmt.Sprintf("%.1f", totalWrite)
+	}
+
+	series := []string{
+		fmt.Sprintf(`{
+			name: "Read KB/s",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, strings.Join(readData, ", ")),
+		fmt.Sprintf(`{
+			name: "Write KB/s",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, strings.Join(writeData, ", ")),
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(series, ", "))
+}
+
+// countUniqueDevices counts the number of unique devices across all snapshots
+func countUniqueDevices(data *IOStatReportData) int {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+	return len(deviceSet)
+}
+
+// findPeakCPUUsage finds the peak CPU usage (100 - idle) across all snapshots
+func findPeakCPUUsage(data *IOStatReportData) float64 {
+	peak := 0.0
+	for _, snapshot := range data.Snapshots {
+		if snapshot.CPUStats != nil {
+			usage := 100.0 - snapshot.CPUStats.Idle
+			if usage > peak {
+				peak = usage
+			}
+		}
+	}
+	return peak
+}
+
+// findPeakDeviceQueueSize finds the peak device average queue size across all snapshots
+func findPeakDeviceQueueSize(data *IOStatReportData) float64 {
+	peak := 0.0
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			if device.AvgQueueSize > peak {
+				peak = device.AvgQueueSize
+			}
+		}
+	}
+	return peak
+}
+
+// extractDeviceAwaitLegendData extracts legend data for device await charts
+func extractDeviceAwaitLegendData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var legends []string
+	for device := range deviceSet {
+		legends = append(legends, fmt.Sprintf(`"%s Read Await"`, device))
+		legends = append(legends, fmt.Sprintf(`"%s Write Await"`, device))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(legends, ", "))
+}
+
+// extractDeviceAwaitSeriesData extracts device await time data for charts
+func extractDeviceAwaitSeriesData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var series []string
+	for device := range deviceSet {
+		readAwaitData := make([]string, len(data.Snapshots))
+		writeAwaitData := make([]string, len(data.Snapshots))
+
+		for i, snapshot := range data.Snapshots {
+			readAwait := 0.0
+			writeAwait := 0.0
+
+			for _, d := range snapshot.Devices {
+				if d.Device == device {
+					readAwait = d.ReadAwait
+					writeAwait = d.WriteAwait
+					break
+				}
+			}
+
+			readAwaitData[i] = fmt.Sprintf("%.2f", readAwait)
+			writeAwaitData[i] = fmt.Sprintf("%.2f", writeAwait)
+		}
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Read Await",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, device, strings.Join(readAwaitData, ", ")))
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Write Await",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, device, strings.Join(writeAwaitData, ", ")))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(series, ", "))
+}
+
+// extractDeviceQueueLegendData extracts legend data for device queue charts
+func extractDeviceQueueLegendData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var legends []string
+	for device := range deviceSet {
+		legends = append(legends, fmt.Sprintf(`"%s Queue Size"`, device))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(legends, ", "))
+}
+
+// extractDeviceQueueSeriesData extracts device queue size data for charts
+func extractDeviceQueueSeriesData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var series []string
+	for device := range deviceSet {
+		queueData := make([]string, len(data.Snapshots))
+
+		for i, snapshot := range data.Snapshots {
+			queueSize := 0.0
+
+			for _, d := range snapshot.Devices {
+				if d.Device == device {
+					queueSize = d.AvgQueueSize
+					break
+				}
+			}
+
+			queueData[i] = fmt.Sprintf("%.2f", queueSize)
+		}
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Queue Size",
+			type: "line",
+			data: [%s],
+			smooth: true,
+			areaStyle: {}
+		}`, device, strings.Join(queueData, ", ")))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(series, ", "))
+}
+
+// extractDeviceRequestsLegendData extracts legend data for device requests charts
+func extractDeviceRequestsLegendData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var legends []string
+	for device := range deviceSet {
+		legends = append(legends, fmt.Sprintf(`"%s Reads/sec"`, device))
+		legends = append(legends, fmt.Sprintf(`"%s Writes/sec"`, device))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(legends, ", "))
+}
+
+// extractDeviceRequestsSeriesData extracts device requests per second data for charts
+func extractDeviceRequestsSeriesData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var series []string
+	for device := range deviceSet {
+		readsData := make([]string, len(data.Snapshots))
+		writesData := make([]string, len(data.Snapshots))
+
+		for i, snapshot := range data.Snapshots {
+			reads := 0.0
+			writes := 0.0
+
+			for _, d := range snapshot.Devices {
+				if d.Device == device {
+					reads = d.ReadsPerS
+					writes = d.WritesPerS
+					break
+				}
+			}
+
+			readsData[i] = fmt.Sprintf("%.2f", reads)
+			writesData[i] = fmt.Sprintf("%.2f", writes)
+		}
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Reads/sec",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, device, strings.Join(readsData, ", ")))
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Writes/sec",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, device, strings.Join(writesData, ", ")))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(series, ", "))
+}
+
+// extractDeviceRequestSizeLegendData extracts legend data for device request size charts
+func extractDeviceRequestSizeLegendData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var legends []string
+	for device := range deviceSet {
+		legends = append(legends, fmt.Sprintf(`"%s Read Size"`, device))
+		legends = append(legends, fmt.Sprintf(`"%s Write Size"`, device))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(legends, ", "))
+}
+
+// extractDeviceRequestSizeSeriesData extracts device request size data for charts
+func extractDeviceRequestSizeSeriesData(data *IOStatReportData) string {
+	deviceSet := make(map[string]bool)
+	for _, snapshot := range data.Snapshots {
+		for _, device := range snapshot.Devices {
+			deviceSet[device.Device] = true
+		}
+	}
+
+	var series []string
+	for device := range deviceSet {
+		readSizeData := make([]string, len(data.Snapshots))
+		writeSizeData := make([]string, len(data.Snapshots))
+
+		for i, snapshot := range data.Snapshots {
+			readSize := 0.0
+			writeSize := 0.0
+
+			for _, d := range snapshot.Devices {
+				if d.Device == device {
+					readSize = d.ReadReqSize
+					writeSize = d.WriteReqSize
+					break
+				}
+			}
+
+			readSizeData[i] = fmt.Sprintf("%.2f", readSize)
+			writeSizeData[i] = fmt.Sprintf("%.2f", writeSize)
+		}
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Read Size",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, device, strings.Join(readSizeData, ", ")))
+
+		series = append(series, fmt.Sprintf(`{
+			name: "%s Write Size",
+			type: "line",
+			data: [%s],
+			smooth: true
+		}`, device, strings.Join(writeSizeData, ", ")))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(series, ", "))
+}

--- a/internal/reporters/iostat_html_report_test.go
+++ b/internal/reporters/iostat_html_report_test.go
@@ -1,0 +1,612 @@
+//	Copyright 2023 Dremio Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporters
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateIOStatHTML(t *testing.T) {
+	t.Run("Generate HTML with ECharts", func(t *testing.T) {
+		// Create test data
+		data := &IOStatReportData{
+			SystemInfo: "Linux 5.10.0-32-cloud-amd64 (test-system)",
+			Snapshots: []IOStatSnapshot{
+				{
+					Timestamp: time.Date(2024, 9, 4, 12, 7, 20, 0, time.UTC),
+					CPUStats: &CPUStats{
+						User:   25.5,
+						Nice:   0.0,
+						System: 10.2,
+						IOWait: 2.1,
+						Steal:  0.5,
+						Idle:   61.7,
+					},
+					Devices: []DeviceStats{
+						{
+							Device:      "sda",
+							ReadsPerS:   5.0,
+							ReadKBPerS:  250.0,
+							WritesPerS:  10.0,
+							WriteKBPerS: 500.0,
+							Utilization: 15.5,
+						},
+						{
+							Device:      "sdb",
+							ReadsPerS:   2.0,
+							ReadKBPerS:  100.0,
+							WritesPerS:  5.0,
+							WriteKBPerS: 200.0,
+							Utilization: 8.2,
+						},
+					},
+				},
+				{
+					Timestamp: time.Date(2024, 9, 4, 12, 7, 21, 0, time.UTC),
+					CPUStats: &CPUStats{
+						User:   30.0,
+						Nice:   1.0,
+						System: 12.5,
+						IOWait: 3.2,
+						Steal:  0.8,
+						Idle:   52.5,
+					},
+					Devices: []DeviceStats{
+						{
+							Device:      "sda",
+							ReadsPerS:   8.0,
+							ReadKBPerS:  400.0,
+							WritesPerS:  15.0,
+							WriteKBPerS: 750.0,
+							Utilization: 22.3,
+						},
+						{
+							Device:      "sdb",
+							ReadsPerS:   3.0,
+							ReadKBPerS:  150.0,
+							WritesPerS:  7.0,
+							WriteKBPerS: 350.0,
+							Utilization: 12.1,
+						},
+					},
+				},
+			},
+		}
+
+		html, err := GenerateIOStatHTML(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, html)
+
+		// Verify ECharts is included
+		assert.Contains(t, html, "echarts.min.js")
+		assert.NotContains(t, html, "chart.js")
+
+		// Verify all chart containers are present
+		assert.Contains(t, html, `id="cpuChart"`)
+		assert.Contains(t, html, `id="ioThroughputChart"`)
+		assert.Contains(t, html, `id="deviceAwaitChart"`)
+		assert.Contains(t, html, `id="deviceQueueChart"`)
+		assert.Contains(t, html, `id="deviceRequestsChart"`)
+		assert.Contains(t, html, `id="deviceRequestSizeChart"`)
+
+		// Verify chart titles
+		assert.Contains(t, html, "CPU Utilization Over Time")
+		assert.Contains(t, html, "Device I/O Throughput Over Time")
+		assert.Contains(t, html, "Device I/O Await Times")
+		assert.Contains(t, html, "Device Average Queue Size")
+		assert.Contains(t, html, "Device I/O Requests Per Second")
+		assert.Contains(t, html, "Device I/O Request Sizes")
+
+		// Verify device utilization chart is NOT present
+		assert.NotContains(t, html, `id="deviceUtilChart"`)
+		assert.NotContains(t, html, "Device Utilization Over Time")
+		assert.NotContains(t, html, "Performance Interpretation Guide")
+
+		// Verify ECharts initialization
+		assert.Contains(t, html, "echarts.init")
+		assert.Contains(t, html, "setOption")
+		assert.Contains(t, html, "resize()")
+
+		// Verify statistics are displayed
+		assert.Contains(t, html, "2") // snapshot count
+		assert.Contains(t, html, "2") // device count (sda, sdb)
+
+		// Verify data is embedded in charts
+		assert.Contains(t, html, "25.5")  // CPU user value
+		assert.Contains(t, html, "10.2")  // CPU system value
+		assert.Contains(t, html, "350.0") // Read KB/s aggregated
+		assert.Contains(t, html, "700.0") // Write KB/s aggregated
+	})
+
+	t.Run("Generate HTML with empty data", func(t *testing.T) {
+		data := &IOStatReportData{
+			SystemInfo: "",
+			Snapshots:  []IOStatSnapshot{},
+		}
+
+		html, err := GenerateIOStatHTML(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, html)
+
+		// Should generate empty state HTML
+		assert.Contains(t, html, "No IOStat Data Available")
+		assert.Contains(t, html, "empty or could not be parsed")
+	})
+
+	t.Run("Generate HTML with nil data", func(t *testing.T) {
+		html, err := GenerateIOStatHTML(nil)
+		require.NoError(t, err)
+		assert.NotEmpty(t, html)
+
+		// Should generate empty state HTML
+		assert.Contains(t, html, "No IOStat Data Available")
+	})
+
+	t.Run("Generate HTML with single snapshot", func(t *testing.T) {
+		data := &IOStatReportData{
+			SystemInfo: "Linux 5.10.0-32-cloud-amd64 (test-system)",
+			Snapshots: []IOStatSnapshot{
+				{
+					Timestamp: time.Date(2024, 9, 4, 12, 7, 20, 0, time.UTC),
+					CPUStats: &CPUStats{
+						User:   15.5,
+						Nice:   0.0,
+						System: 5.2,
+						IOWait: 1.1,
+						Steal:  0.2,
+						Idle:   78.0,
+					},
+					Devices: []DeviceStats{
+						{
+							Device:      "sda",
+							ReadsPerS:   3.0,
+							ReadKBPerS:  150.0,
+							WritesPerS:  6.0,
+							WriteKBPerS: 300.0,
+							Utilization: 10.5,
+						},
+					},
+				},
+			},
+		}
+
+		html, err := GenerateIOStatHTML(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, html)
+		assert.Contains(t, html, "1") // snapshot count
+		assert.Contains(t, html, "1") // device count
+	})
+}
+
+func TestExtractIOStatTimeLabels(t *testing.T) {
+	t.Run("Extract time labels", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{Timestamp: time.Date(2024, 9, 4, 12, 7, 20, 0, time.UTC)},
+				{Timestamp: time.Date(2024, 9, 4, 12, 7, 21, 0, time.UTC)},
+				{Timestamp: time.Date(2024, 9, 4, 12, 7, 22, 0, time.UTC)},
+			},
+		}
+
+		result := extractIOStatTimeLabels(data)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "12:07:20")
+		assert.Contains(t, result, "12:07:21")
+		assert.Contains(t, result, "12:07:22")
+		assert.Contains(t, result, "[")
+		assert.Contains(t, result, "]")
+	})
+}
+
+func TestExtractCPUSeriesData(t *testing.T) {
+	t.Run("Extract CPU series data", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					CPUStats: &CPUStats{
+						User:   25.5,
+						System: 10.2,
+						IOWait: 2.1,
+						Idle:   62.2,
+					},
+				},
+				{
+					CPUStats: &CPUStats{
+						User:   30.0,
+						System: 12.5,
+						IOWait: 3.2,
+						Idle:   54.3,
+					},
+				},
+			},
+		}
+
+		result := extractCPUSeriesData(data)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "User")
+		assert.Contains(t, result, "System")
+		assert.Contains(t, result, "IOWait")
+		assert.Contains(t, result, "Idle")
+		assert.Contains(t, result, "25.5, 30.0") // User values
+		assert.Contains(t, result, "10.2, 12.5") // System values
+		assert.Contains(t, result, "2.1, 3.2")   // IOWait values
+		assert.Contains(t, result, "62.2, 54.3") // Idle values
+	})
+
+	t.Run("Extract CPU series data with missing stats", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{CPUStats: nil},
+				{
+					CPUStats: &CPUStats{
+						User:   15.0,
+						System: 5.0,
+						IOWait: 1.0,
+						Idle:   79.0,
+					},
+				},
+			},
+		}
+
+		result := extractCPUSeriesData(data)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "0, 15.0") // User values (0 for missing, 15.0 for present)
+		assert.Contains(t, result, "0, 5.0")  // System values
+		assert.Contains(t, result, "0, 1.0")  // IOWait values
+		assert.Contains(t, result, "0, 79.0") // Idle values
+	})
+}
+
+func TestExtractIOThroughputSeriesData(t *testing.T) {
+	t.Run("Extract I/O throughput data", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{ReadKBPerS: 100.0, WriteKBPerS: 200.0},
+						{ReadKBPerS: 50.0, WriteKBPerS: 100.0},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{ReadKBPerS: 150.0, WriteKBPerS: 300.0},
+						{ReadKBPerS: 75.0, WriteKBPerS: 150.0},
+					},
+				},
+			},
+		}
+
+		result := extractIOThroughputSeriesData(data)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "Read KB/s")
+		assert.Contains(t, result, "Write KB/s")
+		assert.Contains(t, result, "150.0, 225.0") // Aggregated read values (100+50, 150+75)
+		assert.Contains(t, result, "300.0, 450.0") // Aggregated write values (200+100, 300+150)
+	})
+
+	t.Run("Extract I/O throughput data with no devices", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{Devices: []DeviceStats{}},
+				{Devices: []DeviceStats{}},
+			},
+		}
+
+		result := extractIOThroughputSeriesData(data)
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "0.0, 0.0") // Should have zero values
+	})
+}
+
+func TestCountUniqueDevices(t *testing.T) {
+	t.Run("Count unique devices across snapshots", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{Device: "sda"},
+						{Device: "sdb"},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{Device: "sda"},
+						{Device: "sdb"},
+						{Device: "nvme0n1"},
+					},
+				},
+			},
+		}
+
+		count := countUniqueDevices(data)
+		assert.Equal(t, 3, count) // sda, sdb, nvme0n1
+	})
+
+	t.Run("Count unique devices with no devices", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{Devices: []DeviceStats{}},
+				{Devices: []DeviceStats{}},
+			},
+		}
+
+		count := countUniqueDevices(data)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("Count unique devices with duplicate devices", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{Device: "sda"},
+						{Device: "sda"}, // Duplicate
+					},
+				},
+			},
+		}
+
+		count := countUniqueDevices(data)
+		assert.Equal(t, 1, count) // Only one unique device
+	})
+}
+
+func TestFindPeakCPUUsage(t *testing.T) {
+	t.Run("Find peak CPU usage", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					CPUStats: &CPUStats{Idle: 80.0}, // 20% usage
+				},
+				{
+					CPUStats: &CPUStats{Idle: 60.0}, // 40% usage
+				},
+				{
+					CPUStats: &CPUStats{Idle: 70.0}, // 30% usage
+				},
+			},
+		}
+
+		peak := findPeakCPUUsage(data)
+		assert.Equal(t, 40.0, peak) // 100 - 60 = 40%
+	})
+
+	t.Run("Find peak CPU usage with nil stats", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{CPUStats: nil},
+				{
+					CPUStats: &CPUStats{Idle: 75.0}, // 25% usage
+				},
+			},
+		}
+
+		peak := findPeakCPUUsage(data)
+		assert.Equal(t, 25.0, peak) // 100 - 75 = 25%
+	})
+
+	t.Run("Find peak CPU usage with no snapshots", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{},
+		}
+
+		peak := findPeakCPUUsage(data)
+		assert.Equal(t, 0.0, peak)
+	})
+}
+
+func TestFindPeakDeviceQueueSize(t *testing.T) {
+	t.Run("Find peak device queue size", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{AvgQueueSize: 1.5},
+						{AvgQueueSize: 0.8},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{AvgQueueSize: 2.3},
+						{AvgQueueSize: 1.2},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{AvgQueueSize: 1.8},
+						{AvgQueueSize: 0.9},
+					},
+				},
+			},
+		}
+
+		peak := findPeakDeviceQueueSize(data)
+		assert.Equal(t, 2.3, peak) // Highest queue size across all devices and snapshots
+	})
+
+	t.Run("Find peak device queue size with no devices", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{Devices: []DeviceStats{}},
+				{Devices: []DeviceStats{}},
+			},
+		}
+
+		peak := findPeakDeviceQueueSize(data)
+		assert.Equal(t, 0.0, peak)
+	})
+
+	t.Run("Find peak device queue size with no snapshots", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{},
+		}
+
+		peak := findPeakDeviceQueueSize(data)
+		assert.Equal(t, 0.0, peak)
+	})
+}
+
+func TestGenerateEmptyIOStatHTML(t *testing.T) {
+	t.Run("Generate empty state HTML", func(t *testing.T) {
+		html := generateEmptyIOStatHTML()
+		assert.NotEmpty(t, html)
+		assert.Contains(t, html, "No IOStat Data Available")
+		assert.Contains(t, html, "empty or could not be parsed")
+		assert.Contains(t, html, "<!DOCTYPE html>")
+		assert.Contains(t, html, "</html>")
+	})
+}
+
+func TestExtractDeviceAwaitData(t *testing.T) {
+	t.Run("Extract device await legend and series data", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", ReadAwait: 2.5, WriteAwait: 3.2},
+						{Device: "sdb", ReadAwait: 1.8, WriteAwait: 2.1},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", ReadAwait: 3.1, WriteAwait: 4.0},
+						{Device: "sdb", ReadAwait: 2.2, WriteAwait: 2.8},
+					},
+				},
+			},
+		}
+
+		legend := extractDeviceAwaitLegendData(data)
+		assert.NotEmpty(t, legend)
+		assert.Contains(t, legend, "Read Await")
+		assert.Contains(t, legend, "Write Await")
+		assert.Contains(t, legend, "sda")
+		assert.Contains(t, legend, "sdb")
+
+		series := extractDeviceAwaitSeriesData(data)
+		assert.NotEmpty(t, series)
+		assert.Contains(t, series, "2.50, 3.10") // sda read await values
+		assert.Contains(t, series, "3.20, 4.00") // sda write await values
+		assert.Contains(t, series, "1.80, 2.20") // sdb read await values
+		assert.Contains(t, series, "2.10, 2.80") // sdb write await values
+	})
+}
+
+func TestExtractDeviceQueueData(t *testing.T) {
+	t.Run("Extract device queue legend and series data", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", AvgQueueSize: 1.5},
+						{Device: "sdb", AvgQueueSize: 0.8},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", AvgQueueSize: 2.1},
+						{Device: "sdb", AvgQueueSize: 1.2},
+					},
+				},
+			},
+		}
+
+		legend := extractDeviceQueueLegendData(data)
+		assert.NotEmpty(t, legend)
+		assert.Contains(t, legend, "Queue Size")
+		assert.Contains(t, legend, "sda")
+		assert.Contains(t, legend, "sdb")
+
+		series := extractDeviceQueueSeriesData(data)
+		assert.NotEmpty(t, series)
+		assert.Contains(t, series, "1.50, 2.10") // sda queue size values
+		assert.Contains(t, series, "0.80, 1.20") // sdb queue size values
+		assert.Contains(t, series, "areaStyle")  // Should have area style
+	})
+}
+
+func TestExtractDeviceRequestsData(t *testing.T) {
+	t.Run("Extract device requests legend and series data", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", ReadsPerS: 10.5, WritesPerS: 15.2},
+						{Device: "sdb", ReadsPerS: 5.8, WritesPerS: 8.1},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", ReadsPerS: 12.3, WritesPerS: 18.7},
+						{Device: "sdb", ReadsPerS: 6.9, WritesPerS: 9.4},
+					},
+				},
+			},
+		}
+
+		legend := extractDeviceRequestsLegendData(data)
+		assert.NotEmpty(t, legend)
+		assert.Contains(t, legend, "Reads/sec")
+		assert.Contains(t, legend, "Writes/sec")
+		assert.Contains(t, legend, "sda")
+		assert.Contains(t, legend, "sdb")
+
+		series := extractDeviceRequestsSeriesData(data)
+		assert.NotEmpty(t, series)
+		assert.Contains(t, series, "10.50, 12.30") // sda reads/sec values
+		assert.Contains(t, series, "15.20, 18.70") // sda writes/sec values
+		assert.Contains(t, series, "5.80, 6.90")   // sdb reads/sec values
+		assert.Contains(t, series, "8.10, 9.40")   // sdb writes/sec values
+	})
+}
+
+func TestExtractDeviceRequestSizeData(t *testing.T) {
+	t.Run("Extract device request size legend and series data", func(t *testing.T) {
+		data := &IOStatReportData{
+			Snapshots: []IOStatSnapshot{
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", ReadReqSize: 64.5, WriteReqSize: 128.2},
+						{Device: "sdb", ReadReqSize: 32.8, WriteReqSize: 96.1},
+					},
+				},
+				{
+					Devices: []DeviceStats{
+						{Device: "sda", ReadReqSize: 72.3, WriteReqSize: 140.7},
+						{Device: "sdb", ReadReqSize: 38.9, WriteReqSize: 104.4},
+					},
+				},
+			},
+		}
+
+		legend := extractDeviceRequestSizeLegendData(data)
+		assert.NotEmpty(t, legend)
+		assert.Contains(t, legend, "Read Size")
+		assert.Contains(t, legend, "Write Size")
+		assert.Contains(t, legend, "sda")
+		assert.Contains(t, legend, "sdb")
+
+		series := extractDeviceRequestSizeSeriesData(data)
+		assert.NotEmpty(t, series)
+		assert.Contains(t, series, "64.50, 72.30")   // sda read size values
+		assert.Contains(t, series, "128.20, 140.70") // sda write size values
+		assert.Contains(t, series, "32.80, 38.90")   // sdb read size values
+		assert.Contains(t, series, "96.10, 104.40")  // sdb write size values
+	})
+}

--- a/internal/reporters/iostat_parser.go
+++ b/internal/reporters/iostat_parser.go
@@ -1,0 +1,314 @@
+//	Copyright 2023 Dremio Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporters
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CPUStats represents CPU utilization statistics from iostat
+type CPUStats struct {
+	User   float64 `json:"user"`   // %user - CPU utilization for user level
+	Nice   float64 `json:"nice"`   // %nice - CPU utilization for user level with nice priority
+	System float64 `json:"system"` // %system - CPU utilization for system level
+	IOWait float64 `json:"iowait"` // %iowait - CPU utilization for I/O wait
+	Steal  float64 `json:"steal"`  // %steal - CPU utilization for involuntary wait
+	Idle   float64 `json:"idle"`   // %idle - CPU utilization for idle time
+}
+
+// DeviceStats represents I/O statistics for a single device
+type DeviceStats struct {
+	Device               string  `json:"device"`                   // Device name (e.g., sda)
+	ReadsPerS            float64 `json:"reads_per_s"`              // r/s - reads per second
+	ReadKBPerS           float64 `json:"read_kb_per_s"`            // rkB/s - kilobytes read per second
+	ReadReqMergedPerS    float64 `json:"read_req_merged_per_s"`    // rrqm/s - read requests merged per second
+	ReadReqMergedPct     float64 `json:"read_req_merged_pct"`      // %rrqm - percentage of read requests merged
+	ReadAwait            float64 `json:"read_await"`               // r_await - average time for read requests
+	ReadReqSize          float64 `json:"read_req_size"`            // rareq-sz - average size of read requests
+	WritesPerS           float64 `json:"writes_per_s"`             // w/s - writes per second
+	WriteKBPerS          float64 `json:"write_kb_per_s"`           // wkB/s - kilobytes written per second
+	WriteReqMergedPerS   float64 `json:"write_req_merged_per_s"`   // wrqm/s - write requests merged per second
+	WriteReqMergedPct    float64 `json:"write_req_merged_pct"`     // %wrqm - percentage of write requests merged
+	WriteAwait           float64 `json:"write_await"`              // w_await - average time for write requests
+	WriteReqSize         float64 `json:"write_req_size"`           // wareq-sz - average size of write requests
+	DiscardsPerS         float64 `json:"discards_per_s"`           // d/s - discards per second
+	DiscardKBPerS        float64 `json:"discard_kb_per_s"`         // dkB/s - kilobytes discarded per second
+	DiscardReqMergedPerS float64 `json:"discard_req_merged_per_s"` // drqm/s - discard requests merged per second
+	DiscardReqMergedPct  float64 `json:"discard_req_merged_pct"`   // %drqm - percentage of discard requests merged
+	DiscardAwait         float64 `json:"discard_await"`            // d_await - average time for discard requests
+	DiscardReqSize       float64 `json:"discard_req_size"`         // dareq-sz - average size of discard requests
+	FlushesPerS          float64 `json:"flushes_per_s"`            // f/s - flushes per second
+	FlushAwait           float64 `json:"flush_await"`              // f_await - average time for flush requests
+	AvgQueueSize         float64 `json:"avg_queue_size"`           // aqu-sz - average queue size
+	Utilization          float64 `json:"utilization"`              // %util - device utilization percentage
+}
+
+// IOStatSnapshot represents a single snapshot of system I/O statistics
+type IOStatSnapshot struct {
+	Timestamp time.Time     `json:"timestamp"` // When this snapshot was taken
+	CPUStats  *CPUStats     `json:"cpu_stats"` // CPU utilization statistics
+	Devices   []DeviceStats `json:"devices"`   // I/O statistics for all devices
+}
+
+// IOStatReportData represents the complete parsed iostat report data
+type IOStatReportData struct {
+	SystemInfo string           `json:"system_info"` // System information from header
+	Snapshots  []IOStatSnapshot `json:"snapshots"`   // All snapshots from the iostat output
+}
+
+// ParseIOStat parses iostat output content and extracts I/O statistics over time
+func ParseIOStat(content []byte) (*IOStatReportData, error) {
+	if len(content) == 0 {
+		return &IOStatReportData{Snapshots: []IOStatSnapshot{}}, nil
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	var snapshots []IOStatSnapshot
+	var currentSnapshot *IOStatSnapshot
+	var systemInfo string
+	var inDeviceSection bool
+	var lineNumber int
+	var expectingCPUStats bool
+
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		// Capture system information from the first line
+		if systemInfo == "" && strings.Contains(line, "Linux") {
+			systemInfo = line
+			continue
+		}
+
+		// Check if this line contains a timestamp (MM/DD/YY format)
+		if isTimestampLine(line) {
+			// Validate previous snapshot if it exists
+			if currentSnapshot != nil {
+				if expectingCPUStats {
+					return nil, fmt.Errorf("line %d: expected CPU statistics after timestamp, but found another timestamp", lineNumber)
+				}
+				snapshots = append(snapshots, *currentSnapshot)
+			}
+
+			// Parse timestamp
+			timestamp, err := parseIOStatTimestamp(line)
+			if err != nil {
+				return nil, fmt.Errorf("line %d: failed to parse timestamp: %w", lineNumber, err)
+			}
+
+			// Start new snapshot
+			currentSnapshot = &IOStatSnapshot{
+				Timestamp: timestamp,
+				CPUStats:  nil,
+				Devices:   []DeviceStats{},
+			}
+			inDeviceSection = false
+			expectingCPUStats = true
+			continue
+		}
+
+		// Check if this line contains CPU statistics header
+		if strings.HasPrefix(line, "avg-cpu:") && currentSnapshot != nil {
+			if !expectingCPUStats {
+				return nil, fmt.Errorf("line %d: unexpected CPU statistics header", lineNumber)
+			}
+			inDeviceSection = false
+			continue // Skip the header line
+		}
+
+		// Parse CPU statistics line (the line after avg-cpu header)
+		if expectingCPUStats && currentSnapshot != nil && currentSnapshot.CPUStats == nil && !strings.HasPrefix(line, "Device") && !strings.HasPrefix(line, "avg-cpu:") && !isTimestampLine(line) {
+			// Try to parse as CPU stats - should have 6 numeric fields
+			fields := strings.Fields(line)
+			if len(fields) == 6 {
+				cpuStats, err := parseCPUStatsLine(line)
+				if err != nil {
+					return nil, fmt.Errorf("line %d: failed to parse CPU statistics: %w", lineNumber, err)
+				}
+				currentSnapshot.CPUStats = cpuStats
+				expectingCPUStats = false
+			} else if len(fields) > 0 {
+				// Non-empty line that doesn't have 6 fields when we expect CPU stats
+				return nil, fmt.Errorf("line %d: expected CPU statistics with 6 fields, got %d fields", lineNumber, len(fields))
+			}
+			continue
+		}
+
+		// Check if this line is the device header
+		if strings.HasPrefix(line, "Device") {
+			inDeviceSection = true
+			continue
+		}
+
+		// Parse device statistics
+		if inDeviceSection && currentSnapshot != nil {
+			deviceStats, err := parseDeviceStatsLine(line)
+			if err != nil {
+				return nil, fmt.Errorf("line %d: failed to parse device statistics: %w", lineNumber, err)
+			}
+			currentSnapshot.Devices = append(currentSnapshot.Devices, deviceStats)
+		}
+	}
+
+	// Validate the last snapshot
+	if currentSnapshot != nil {
+		if expectingCPUStats {
+			return nil, fmt.Errorf("line %d: expected CPU statistics after timestamp, but reached end of file", lineNumber)
+		}
+		snapshots = append(snapshots, *currentSnapshot)
+	}
+
+	return &IOStatReportData{
+		SystemInfo: systemInfo,
+		Snapshots:  snapshots,
+	}, nil
+}
+
+// isTimestampLine checks if a line contains a timestamp in MM/DD/YY format
+func isTimestampLine(line string) bool {
+	// Look for pattern like "09/04/24 12:07:20"
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return false
+	}
+
+	// Check if first part looks like MM/DD/YY
+	datePart := parts[0]
+	if len(datePart) == 8 && strings.Count(datePart, "/") == 2 {
+		return true
+	}
+
+	return false
+}
+
+// parseIOStatTimestamp parses timestamp from a line like "09/04/24 12:07:20"
+func parseIOStatTimestamp(line string) (time.Time, error) {
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return time.Time{}, fmt.Errorf("invalid timestamp line format")
+	}
+
+	dateTimeStr := parts[0] + " " + parts[1]
+
+	// Parse MM/DD/YY HH:MM:SS format
+	parsedTime, err := time.Parse("01/02/06 15:04:05", dateTimeStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse timestamp %s: %w", dateTimeStr, err)
+	}
+
+	return parsedTime, nil
+}
+
+// parseCPUStatsLine parses a line with CPU statistics
+func parseCPUStatsLine(line string) (*CPUStats, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 6 {
+		return nil, fmt.Errorf("expected 6 CPU stat fields, got %d", len(fields))
+	}
+
+	user, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user CPU: %w", err)
+	}
+
+	nice, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse nice CPU: %w", err)
+	}
+
+	system, err := strconv.ParseFloat(fields[2], 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse system CPU: %w", err)
+	}
+
+	iowait, err := strconv.ParseFloat(fields[3], 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse iowait CPU: %w", err)
+	}
+
+	steal, err := strconv.ParseFloat(fields[4], 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse steal CPU: %w", err)
+	}
+
+	idle, err := strconv.ParseFloat(fields[5], 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse idle CPU: %w", err)
+	}
+
+	return &CPUStats{
+		User:   user,
+		Nice:   nice,
+		System: system,
+		IOWait: iowait,
+		Steal:  steal,
+		Idle:   idle,
+	}, nil
+}
+
+// parseDeviceStatsLine parses a line with device I/O statistics
+func parseDeviceStatsLine(line string) (DeviceStats, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 23 {
+		return DeviceStats{}, fmt.Errorf("expected 23 device stat fields, got %d", len(fields))
+	}
+
+	device := fields[0]
+
+	// Parse all numeric fields
+	values := make([]float64, 22)
+	for i := 1; i < 23; i++ {
+		val, err := strconv.ParseFloat(fields[i], 64)
+		if err != nil {
+			return DeviceStats{}, fmt.Errorf("failed to parse field %d: %w", i, err)
+		}
+		values[i-1] = val
+	}
+
+	return DeviceStats{
+		Device:               device,
+		ReadsPerS:            values[0],
+		ReadKBPerS:           values[1],
+		ReadReqMergedPerS:    values[2],
+		ReadReqMergedPct:     values[3],
+		ReadAwait:            values[4],
+		ReadReqSize:          values[5],
+		WritesPerS:           values[6],
+		WriteKBPerS:          values[7],
+		WriteReqMergedPerS:   values[8],
+		WriteReqMergedPct:    values[9],
+		WriteAwait:           values[10],
+		WriteReqSize:         values[11],
+		DiscardsPerS:         values[12],
+		DiscardKBPerS:        values[13],
+		DiscardReqMergedPerS: values[14],
+		DiscardReqMergedPct:  values[15],
+		DiscardAwait:         values[16],
+		DiscardReqSize:       values[17],
+		FlushesPerS:          values[18],
+		FlushAwait:           values[19],
+		AvgQueueSize:         values[20],
+		Utilization:          values[21],
+	}, nil
+}

--- a/internal/reporters/iostat_parser_test.go
+++ b/internal/reporters/iostat_parser_test.go
@@ -1,0 +1,476 @@
+//	Copyright 2023 Dremio Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporters
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIOStat(t *testing.T) {
+	t.Run("Parse valid iostat content with multiple snapshots", func(t *testing.T) {
+		sampleContent := `Linux 5.10.0-32-cloud-amd64 (ddc-test-dremio-master) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39
+
+
+09/04/24 12:07:21
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          33.91    0.00    7.67    2.72    0.00   55.69
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              0.00      0.00     0.00   0.00    0.00     0.00  395.00  38116.00   133.00  25.19    8.65    96.50    1.00      4.00     0.00   0.00    1.00     4.00  122.00    0.06    3.42  39.20`
+
+		data, err := ParseIOStat([]byte(sampleContent))
+		require.NoError(t, err)
+		require.NotNil(t, data)
+
+		// Should have exactly 2 snapshots
+		assert.Len(t, data.Snapshots, 2)
+
+		// Check system info
+		assert.Contains(t, data.SystemInfo, "Linux 5.10.0-32-cloud-amd64")
+		assert.Contains(t, data.SystemInfo, "ddc-test-dremio-master")
+
+		// Check first snapshot
+		snapshot1 := data.Snapshots[0]
+		assert.Equal(t, 2024, snapshot1.Timestamp.Year())
+		assert.Equal(t, time.September, snapshot1.Timestamp.Month())
+		assert.Equal(t, 4, snapshot1.Timestamp.Day())
+		assert.Equal(t, 12, snapshot1.Timestamp.Hour())
+		assert.Equal(t, 7, snapshot1.Timestamp.Minute())
+		assert.Equal(t, 20, snapshot1.Timestamp.Second())
+
+		// Check CPU stats for first snapshot
+		require.NotNil(t, snapshot1.CPUStats)
+		assert.Equal(t, 2.36, snapshot1.CPUStats.User)
+		assert.Equal(t, 0.00, snapshot1.CPUStats.Nice)
+		assert.Equal(t, 0.40, snapshot1.CPUStats.System)
+		assert.Equal(t, 0.04, snapshot1.CPUStats.IOWait)
+		assert.Equal(t, 0.01, snapshot1.CPUStats.Steal)
+		assert.Equal(t, 97.20, snapshot1.CPUStats.Idle)
+
+		// Check device stats for first snapshot
+		assert.Len(t, snapshot1.Devices, 1)
+		device1 := snapshot1.Devices[0]
+		assert.Equal(t, "sda", device1.Device)
+		assert.Equal(t, 2.08, device1.ReadsPerS)
+		assert.Equal(t, 94.38, device1.ReadKBPerS)
+		assert.Equal(t, 0.31, device1.ReadReqMergedPerS)
+		assert.Equal(t, 13.07, device1.ReadReqMergedPct)
+		assert.Equal(t, 0.89, device1.ReadAwait)
+		assert.Equal(t, 45.47, device1.ReadReqSize)
+		assert.Equal(t, 9.58, device1.WritesPerS)
+		assert.Equal(t, 210.39, device1.WriteKBPerS)
+		assert.Equal(t, 1.39, device1.Utilization)
+
+		// Check second snapshot
+		snapshot2 := data.Snapshots[1]
+		assert.Equal(t, 12, snapshot2.Timestamp.Hour())
+		assert.Equal(t, 7, snapshot2.Timestamp.Minute())
+		assert.Equal(t, 21, snapshot2.Timestamp.Second())
+
+		// Check CPU stats for second snapshot
+		require.NotNil(t, snapshot2.CPUStats)
+		assert.Equal(t, 33.91, snapshot2.CPUStats.User)
+		assert.Equal(t, 7.67, snapshot2.CPUStats.System)
+		assert.Equal(t, 2.72, snapshot2.CPUStats.IOWait)
+		assert.Equal(t, 55.69, snapshot2.CPUStats.Idle)
+
+		// Check device stats for second snapshot
+		assert.Len(t, snapshot2.Devices, 1)
+		device2 := snapshot2.Devices[0]
+		assert.Equal(t, "sda", device2.Device)
+		assert.Equal(t, 0.00, device2.ReadsPerS)
+		assert.Equal(t, 395.00, device2.WritesPerS)
+		assert.Equal(t, 38116.00, device2.WriteKBPerS)
+		assert.Equal(t, 39.20, device2.Utilization)
+	})
+
+	t.Run("Parse empty content", func(t *testing.T) {
+		data, err := ParseIOStat([]byte(""))
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Empty(t, data.Snapshots)
+	})
+
+	t.Run("Parse content with no valid snapshots", func(t *testing.T) {
+		content := `Some random content
+That doesn't match
+The expected format`
+
+		data, err := ParseIOStat([]byte(content))
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Empty(t, data.Snapshots)
+	})
+
+	t.Run("Parse content with malformed device lines should error", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39
+invalid line with not enough fields
+sdb              1.00     50.00     0.20  10.00    1.00    50.00    5.00    100.00     2.00  20.00    3.00    20.00    0.00      0.00     0.00   0.00    0.00     0.00    2.00    0.05    0.02   2.00`
+
+		_, err := ParseIOStat([]byte(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse device statistics")
+		assert.Contains(t, err.Error(), "line 9")
+	})
+
+	t.Run("Parse content with single snapshot", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 15:30:45
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          25.50   10.20    5.30    2.10    1.00   55.90
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              5.00    250.00     1.00  20.00    2.00    50.00   10.00    500.00     3.00  30.00    4.00    50.00    0.50     25.00     0.10   5.00    3.00    50.00    1.00    0.10    0.05  15.50`
+
+		data, err := ParseIOStat([]byte(content))
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Len(t, data.Snapshots, 1)
+
+		snapshot := data.Snapshots[0]
+		assert.Equal(t, 15, snapshot.Timestamp.Hour())
+		assert.Equal(t, 30, snapshot.Timestamp.Minute())
+		assert.Equal(t, 45, snapshot.Timestamp.Second())
+
+		// Check CPU stats
+		require.NotNil(t, snapshot.CPUStats)
+		assert.Equal(t, 25.50, snapshot.CPUStats.User)
+		assert.Equal(t, 10.20, snapshot.CPUStats.Nice)
+		assert.Equal(t, 5.30, snapshot.CPUStats.System)
+		assert.Equal(t, 2.10, snapshot.CPUStats.IOWait)
+		assert.Equal(t, 1.00, snapshot.CPUStats.Steal)
+		assert.Equal(t, 55.90, snapshot.CPUStats.Idle)
+
+		// Check device stats
+		assert.Len(t, snapshot.Devices, 1)
+		device := snapshot.Devices[0]
+		assert.Equal(t, "sda", device.Device)
+		assert.Equal(t, 5.00, device.ReadsPerS)
+		assert.Equal(t, 250.00, device.ReadKBPerS)
+		assert.Equal(t, 10.00, device.WritesPerS)
+		assert.Equal(t, 500.00, device.WriteKBPerS)
+		assert.Equal(t, 15.50, device.Utilization)
+	})
+}
+
+func TestParseIOStatTimestamp(t *testing.T) {
+	t.Run("Valid timestamp parsing", func(t *testing.T) {
+		line := "09/04/24 12:07:20"
+		timestamp, err := parseIOStatTimestamp(line)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2024, timestamp.Year())
+		assert.Equal(t, time.September, timestamp.Month())
+		assert.Equal(t, 4, timestamp.Day())
+		assert.Equal(t, 12, timestamp.Hour())
+		assert.Equal(t, 7, timestamp.Minute())
+		assert.Equal(t, 20, timestamp.Second())
+	})
+
+	t.Run("Invalid timestamp format", func(t *testing.T) {
+		line := "invalid timestamp"
+		_, err := parseIOStatTimestamp(line)
+		require.Error(t, err)
+	})
+
+	t.Run("Missing timestamp parts", func(t *testing.T) {
+		line := "09/04/24"
+		_, err := parseIOStatTimestamp(line)
+		require.Error(t, err)
+	})
+}
+
+func TestIsTimestampLine(t *testing.T) {
+	t.Run("Valid timestamp line", func(t *testing.T) {
+		line := "09/04/24 12:07:20"
+		assert.True(t, isTimestampLine(line))
+	})
+
+	t.Run("Invalid timestamp line - no time", func(t *testing.T) {
+		line := "09/04/24"
+		assert.False(t, isTimestampLine(line))
+	})
+
+	t.Run("Invalid timestamp line - wrong format", func(t *testing.T) {
+		line := "2024-09-04 12:07:20"
+		assert.False(t, isTimestampLine(line))
+	})
+
+	t.Run("Invalid timestamp line - not a timestamp", func(t *testing.T) {
+		line := "avg-cpu:  %user   %nice %system %iowait  %steal   %idle"
+		assert.False(t, isTimestampLine(line))
+	})
+}
+
+func TestParseCPUStatsLine(t *testing.T) {
+	t.Run("Valid CPU stats line", func(t *testing.T) {
+		line := "           2.36    0.00    0.40    0.04    0.01   97.20"
+
+		stats, err := parseCPUStatsLine(line)
+		require.NoError(t, err)
+		require.NotNil(t, stats)
+
+		assert.Equal(t, 2.36, stats.User)
+		assert.Equal(t, 0.00, stats.Nice)
+		assert.Equal(t, 0.40, stats.System)
+		assert.Equal(t, 0.04, stats.IOWait)
+		assert.Equal(t, 0.01, stats.Steal)
+		assert.Equal(t, 97.20, stats.Idle)
+	})
+
+	t.Run("Invalid CPU stats line - insufficient fields", func(t *testing.T) {
+		line := "2.36 0.00 0.40"
+		_, err := parseCPUStatsLine(line)
+		require.Error(t, err)
+	})
+
+	t.Run("Invalid CPU stats line - non-numeric values", func(t *testing.T) {
+		line := "invalid 0.00 0.40 0.04 0.01 97.20"
+		_, err := parseCPUStatsLine(line)
+		require.Error(t, err)
+	})
+}
+
+func TestParseDeviceStatsLine(t *testing.T) {
+	t.Run("Valid device stats line", func(t *testing.T) {
+		line := "sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39"
+
+		device, err := parseDeviceStatsLine(line)
+		require.NoError(t, err)
+
+		assert.Equal(t, "sda", device.Device)
+		assert.Equal(t, 2.08, device.ReadsPerS)
+		assert.Equal(t, 94.38, device.ReadKBPerS)
+		assert.Equal(t, 0.31, device.ReadReqMergedPerS)
+		assert.Equal(t, 13.07, device.ReadReqMergedPct)
+		assert.Equal(t, 0.89, device.ReadAwait)
+		assert.Equal(t, 45.47, device.ReadReqSize)
+		assert.Equal(t, 9.58, device.WritesPerS)
+		assert.Equal(t, 210.39, device.WriteKBPerS)
+		assert.Equal(t, 5.55, device.WriteReqMergedPerS)
+		assert.Equal(t, 36.68, device.WriteReqMergedPct)
+		assert.Equal(t, 2.74, device.WriteAwait)
+		assert.Equal(t, 21.96, device.WriteReqSize)
+		assert.Equal(t, 0.09, device.DiscardsPerS)
+		assert.Equal(t, 377.20, device.DiscardKBPerS)
+		assert.Equal(t, 0.00, device.DiscardReqMergedPerS)
+		assert.Equal(t, 0.00, device.DiscardReqMergedPct)
+		assert.Equal(t, 0.95, device.DiscardAwait)
+		assert.Equal(t, 4151.86, device.DiscardReqSize)
+		assert.Equal(t, 3.94, device.FlushesPerS)
+		assert.Equal(t, 0.06, device.FlushAwait)
+		assert.Equal(t, 0.03, device.AvgQueueSize)
+		assert.Equal(t, 1.39, device.Utilization)
+	})
+
+	t.Run("Invalid device stats line - insufficient fields", func(t *testing.T) {
+		line := "sda 2.08 94.38"
+		_, err := parseDeviceStatsLine(line)
+		require.Error(t, err)
+	})
+
+	t.Run("Invalid device stats line - non-numeric values", func(t *testing.T) {
+		line := "sda invalid 94.38 0.31 13.07 0.89 45.47 9.58 210.39 5.55 36.68 2.74 21.96 0.09 377.20 0.00 0.00 0.95 4151.86 3.94 0.06 0.03 1.39"
+		_, err := parseDeviceStatsLine(line)
+		require.Error(t, err)
+	})
+
+	t.Run("Device stats with zero values", func(t *testing.T) {
+		line := "sdb              0.00      0.00     0.00   0.00    0.00     0.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.00   0.00"
+
+		device, err := parseDeviceStatsLine(line)
+		require.NoError(t, err)
+
+		assert.Equal(t, "sdb", device.Device)
+		assert.Equal(t, 0.00, device.ReadsPerS)
+		assert.Equal(t, 0.00, device.ReadKBPerS)
+		assert.Equal(t, 0.00, device.WritesPerS)
+		assert.Equal(t, 0.00, device.WriteKBPerS)
+		assert.Equal(t, 0.00, device.Utilization)
+	})
+}
+
+func TestIOStatReportDataStructure(t *testing.T) {
+	t.Run("Data structure creation and access", func(t *testing.T) {
+		// Create test data
+		timestamp := time.Date(2024, 9, 4, 12, 7, 20, 0, time.UTC)
+		cpuStats := &CPUStats{
+			User:   25.5,
+			Nice:   0.0,
+			System: 10.2,
+			IOWait: 2.1,
+			Steal:  0.5,
+			Idle:   61.7,
+		}
+		deviceStats := DeviceStats{
+			Device:      "sda",
+			ReadsPerS:   5.0,
+			ReadKBPerS:  250.0,
+			WritesPerS:  10.0,
+			WriteKBPerS: 500.0,
+			Utilization: 15.5,
+		}
+
+		snapshot := IOStatSnapshot{
+			Timestamp: timestamp,
+			CPUStats:  cpuStats,
+			Devices:   []DeviceStats{deviceStats},
+		}
+
+		data := IOStatReportData{
+			SystemInfo: "Linux 5.10.0-32-cloud-amd64 (test-system)",
+			Snapshots:  []IOStatSnapshot{snapshot},
+		}
+
+		// Verify structure
+		assert.Len(t, data.Snapshots, 1)
+		assert.Equal(t, timestamp, data.Snapshots[0].Timestamp)
+		assert.Equal(t, cpuStats, data.Snapshots[0].CPUStats)
+		assert.Len(t, data.Snapshots[0].Devices, 1)
+		assert.Equal(t, deviceStats, data.Snapshots[0].Devices[0])
+		assert.Contains(t, data.SystemInfo, "Linux")
+	})
+}
+
+func TestIOStatParserEdgeCases(t *testing.T) {
+	t.Run("Parse content with missing CPU stats should error", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39`
+
+		_, err := ParseIOStat([]byte(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected CPU statistics")
+		assert.Contains(t, err.Error(), "line")
+	})
+
+	t.Run("Parse content with missing device stats", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20`
+
+		data, err := ParseIOStat([]byte(content))
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Len(t, data.Snapshots, 1)
+
+		// CPU stats should be present
+		require.NotNil(t, data.Snapshots[0].CPUStats)
+		assert.Equal(t, 2.36, data.Snapshots[0].CPUStats.User)
+		// But device stats should be empty
+		assert.Empty(t, data.Snapshots[0].Devices)
+	})
+
+	t.Run("Parse content with multiple devices", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39
+sdb              1.00     50.00     0.20  10.00    1.00    50.00    5.00    100.00     2.00  20.00    3.00    20.00    0.00      0.00     0.00   0.00    0.00     0.00    2.00    0.05    0.02   2.00
+nvme0n1          5.50    275.00     1.50  25.00    1.50    50.00   15.00    750.00     7.50  33.33    5.00    50.00    0.25     12.50     0.05   2.50    2.50    50.00    3.00    0.08    0.10  25.75`
+
+		data, err := ParseIOStat([]byte(content))
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Len(t, data.Snapshots, 1)
+
+		// Should have 3 devices
+		assert.Len(t, data.Snapshots[0].Devices, 3)
+		assert.Equal(t, "sda", data.Snapshots[0].Devices[0].Device)
+		assert.Equal(t, "sdb", data.Snapshots[0].Devices[1].Device)
+		assert.Equal(t, "nvme0n1", data.Snapshots[0].Devices[2].Device)
+	})
+
+	t.Run("Parse content with malformed CPU stats should error with line number", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           invalid    0.00    0.40    0.04    0.01   97.20`
+
+		_, err := ParseIOStat([]byte(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse CPU statistics")
+		assert.Contains(t, err.Error(), "line 5")
+	})
+
+	t.Run("Parse content with malformed device stats should error with line number", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              invalid     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39`
+
+		_, err := ParseIOStat([]byte(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse device statistics")
+		assert.Contains(t, err.Error(), "line 8")
+	})
+
+	t.Run("Parse content with wrong number of CPU fields should error with line number", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04`
+
+		_, err := ParseIOStat([]byte(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected CPU statistics with 6 fields, got 4 fields")
+		assert.Contains(t, err.Error(), "line 5")
+	})
+
+	t.Run("Parse content ending without CPU stats should error", func(t *testing.T) {
+		content := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20`
+
+		_, err := ParseIOStat([]byte(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected CPU statistics after timestamp")
+		assert.Contains(t, err.Error(), "reached end of file")
+	})
+}

--- a/internal/reporters/reporters.go
+++ b/internal/reporters/reporters.go
@@ -97,20 +97,55 @@ func GenerateTTopReport(filePath string) (string, error) {
 	return string(reportJSON), nil
 }
 
-// GenerateIOStatReport generates a report for iostat files
+// GenerateIOStatReport generates a comprehensive report for iostat files
+// This function parses iostat output to extract I/O statistics over time
+// and generates both a JSON summary and an HTML report with interactive charts
 func GenerateIOStatReport(filePath string) (string, error) {
 	content, err := secureReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}
 
-	// Parse iostat content and generate report
+	// Parse iostat content to extract structured data
+	parsedData, err := ParseIOStat(content)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse iostat content: %w", err)
+	}
+
+	// Generate HTML report with charts
+	htmlReport, err := GenerateIOStatHTML(parsedData)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate HTML report: %w", err)
+	}
+
+	// Calculate summary statistics
+	snapshotCount := len(parsedData.Snapshots)
+	uniqueDevices := countUniqueDevices(parsedData)
+	peakCPUUsage := findPeakCPUUsage(parsedData)
+	peakDeviceQueueSize := findPeakDeviceQueueSize(parsedData)
+
+	// Generate summary and analysis text
+	summary := fmt.Sprintf("IOStat analysis report covering %d snapshots with %d devices monitored",
+		snapshotCount, uniqueDevices)
+
+	analysis := fmt.Sprintf("Peak CPU usage: %.1f%%, Peak device queue size: %.1f. "+
+		"Analysis includes CPU utilization over time, I/O throughput patterns, await times, "+
+		"queue sizes, and request patterns. Interactive charts provide detailed visualization of system I/O performance.",
+		peakCPUUsage, peakDeviceQueueSize)
+
+	// Build comprehensive report structure
 	report := map[string]interface{}{
-		"type":         "iostat",
-		"file_size":    len(content),
-		"summary":      "IOStat analysis report",
-		"analysis":     "Basic iostat file analysis - implementation pending",
-		"generated_at": "2024-01-01T00:00:00Z", // TODO: use actual timestamp
+		"type":                   "iostat",
+		"file_size":              len(content),
+		"summary":                summary,
+		"analysis":               analysis,
+		"generated_at":           fmt.Sprintf("%s", time.Now().Format(time.RFC3339)),
+		"html_report":            htmlReport,
+		"snapshot_count":         snapshotCount,
+		"unique_devices":         uniqueDevices,
+		"peak_cpu_usage":         peakCPUUsage,
+		"peak_device_queue_size": peakDeviceQueueSize,
+		"system_info":            parsedData.SystemInfo,
 	}
 
 	reportJSON, err := json.Marshal(report)

--- a/internal/reporters/reporters_test.go
+++ b/internal/reporters/reporters_test.go
@@ -100,6 +100,156 @@ func TestGenerateTTopReport(t *testing.T) {
 	})
 }
 
+func TestGenerateIOStatReport(t *testing.T) {
+	t.Run("Valid iostat file", func(t *testing.T) {
+		// Create a temporary iostat file
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "iostat.txt")
+
+		iostatContent := `Linux 5.10.0-32-cloud-amd64 (ddc-test-dremio-master) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39
+
+
+09/04/24 12:07:21
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          33.91    0.00    7.67    2.72    0.00   55.69
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              0.00      0.00     0.00   0.00    0.00     0.00  395.00  38116.00   133.00  25.19    8.65    96.50    1.00      4.00     0.00   0.00    1.00     4.00  122.00    0.06    3.42  39.20`
+
+		err := os.WriteFile(filePath, []byte(iostatContent), 0644)
+		require.NoError(t, err)
+
+		// Generate report
+		reportJSON, err := GenerateIOStatReport(filePath)
+		require.NoError(t, err)
+		assert.NotEmpty(t, reportJSON)
+
+		// Parse and validate the report
+		var report map[string]interface{}
+		err = json.Unmarshal([]byte(reportJSON), &report)
+		require.NoError(t, err)
+
+		// Check basic fields
+		assert.Equal(t, "iostat", report["type"])
+		assert.Equal(t, float64(len(iostatContent)), report["file_size"])
+		assert.Contains(t, report, "summary")
+		assert.Contains(t, report, "analysis")
+		assert.Contains(t, report, "generated_at")
+		assert.Contains(t, report, "html_report")
+
+		// Check iostat-specific fields
+		assert.Contains(t, report, "snapshot_count")
+		assert.Contains(t, report, "unique_devices")
+		assert.Contains(t, report, "peak_cpu_usage")
+		assert.Contains(t, report, "peak_device_queue_size")
+		assert.Contains(t, report, "system_info")
+
+		// Verify values
+		assert.Equal(t, float64(2), report["snapshot_count"])
+		assert.Equal(t, float64(1), report["unique_devices"])
+		assert.Contains(t, report["system_info"], "Linux")
+		assert.Contains(t, report["system_info"], "ddc-test-dremio-master")
+
+		// Verify HTML report
+		htmlReport := report["html_report"].(string)
+		assert.Contains(t, htmlReport, "<!DOCTYPE html>")
+		assert.Contains(t, htmlReport, "IOStat Analysis Report")
+		assert.Contains(t, htmlReport, "echarts.min.js")
+	})
+
+	t.Run("Empty iostat file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "empty_iostat.txt")
+
+		err := os.WriteFile(filePath, []byte(""), 0644)
+		require.NoError(t, err)
+
+		reportJSON, err := GenerateIOStatReport(filePath)
+		require.NoError(t, err)
+
+		var report map[string]interface{}
+		err = json.Unmarshal([]byte(reportJSON), &report)
+		require.NoError(t, err)
+
+		assert.Equal(t, "iostat", report["type"])
+		assert.Equal(t, float64(0), report["file_size"])
+		assert.Equal(t, float64(0), report["snapshot_count"])
+		assert.Equal(t, float64(0), report["unique_devices"])
+	})
+
+	t.Run("Malformed iostat file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "malformed_iostat.txt")
+
+		malformedContent := `This is not a valid iostat file
+It contains random text
+That should not cause the parser to crash`
+
+		err := os.WriteFile(filePath, []byte(malformedContent), 0644)
+		require.NoError(t, err)
+
+		reportJSON, err := GenerateIOStatReport(filePath)
+		require.NoError(t, err)
+
+		var report map[string]interface{}
+		err = json.Unmarshal([]byte(reportJSON), &report)
+		require.NoError(t, err)
+
+		assert.Equal(t, "iostat", report["type"])
+		assert.Equal(t, float64(0), report["snapshot_count"])
+		assert.Equal(t, float64(0), report["unique_devices"])
+	})
+
+	t.Run("Large iostat file with multiple devices", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "large_iostat.txt")
+
+		// Create a larger iostat file with multiple devices and snapshots
+		largeContent := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(8 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          25.50    1.20    8.30    3.40    0.60   61.00
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              5.00    250.00     1.00  20.00    2.00    50.00   10.00    500.00     3.00  30.00    4.00    50.00    0.50     25.00     0.10   5.00    3.00    50.00    1.00    0.10    0.05  25.50
+sdb              3.00    150.00     0.50  15.00    1.50    50.00    6.00    300.00     2.00  25.00    3.50    50.00    0.25     12.50     0.05   2.50    2.50    50.00    0.50    0.08    0.03  15.75
+nvme0n1          8.00    400.00     2.00  25.00    1.00    50.00   16.00    800.00     5.00  31.25    2.50    50.00    1.00     50.00     0.20  10.00    2.00    50.00    2.00    0.05    0.08  35.25
+
+09/04/24 12:07:21
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          30.00    0.80    10.20    4.50    0.50   54.00
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              7.00    350.00     1.50  21.43    2.20    50.00   14.00    700.00     4.00  28.57    4.20    50.00    0.70     35.00     0.15   7.14    3.20    50.00    1.40    0.12    0.07  32.50
+sdb              4.00    200.00     0.75  18.75    1.75    50.00    8.00    400.00     2.50  31.25    3.75    50.00    0.40     20.00     0.08   4.00    2.75    50.00    0.80    0.10    0.04  20.25
+nvme0n1         10.00    500.00     2.50  25.00    1.10    50.00   20.00   1000.00     6.00  30.00    2.60    50.00    1.50     75.00     0.30  12.00    2.10    50.00    3.00    0.06    0.10  42.75`
+
+		err := os.WriteFile(filePath, []byte(largeContent), 0644)
+		require.NoError(t, err)
+
+		reportJSON, err := GenerateIOStatReport(filePath)
+		require.NoError(t, err)
+
+		var report map[string]interface{}
+		err = json.Unmarshal([]byte(reportJSON), &report)
+		require.NoError(t, err)
+
+		assert.Equal(t, "iostat", report["type"])
+		assert.Equal(t, float64(2), report["snapshot_count"])
+		assert.Equal(t, float64(3), report["unique_devices"]) // sda, sdb, nvme0n1
+		assert.Greater(t, report["peak_cpu_usage"].(float64), 40.0)
+		assert.Greater(t, report["peak_device_queue_size"].(float64), 0.05)
+	})
+}
+
 func TestReportGeneration_Integration(t *testing.T) {
 	t.Run("Generate reports for all sample file types", func(t *testing.T) {
 		tempDir := t.TempDir()
@@ -123,6 +273,57 @@ func TestReportGeneration_Integration(t *testing.T) {
 		for _, field := range requiredFields {
 			assert.Contains(t, reportData, field, "Report should contain field: %s", field)
 		}
+
+		// Test iostat report generation
+		iostatPath := filepath.Join(tempDir, "iostat.txt")
+		iostatContent := `Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39
+
+09/04/24 12:07:21
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          33.91    0.00    7.67    2.72    0.00   55.69
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              0.00      0.00     0.00   0.00    0.00     0.00  395.00  38116.00   133.00  25.19    8.65    96.50    1.00      4.00     0.00   0.00    1.00     4.00  122.00    0.06    3.42  39.20`
+
+		err = os.WriteFile(iostatPath, []byte(iostatContent), 0644)
+		require.NoError(t, err)
+
+		iostatReport, err := GenerateIOStatReport(iostatPath)
+		require.NoError(t, err)
+		assert.NotEmpty(t, iostatReport)
+
+		// Validate iostat JSON structure
+		var iostatReportData map[string]interface{}
+		err = json.Unmarshal([]byte(iostatReport), &iostatReportData)
+		require.NoError(t, err)
+
+		assert.Equal(t, "iostat", iostatReportData["type"])
+		assert.Contains(t, iostatReportData, "html_report")
+		assert.Contains(t, iostatReportData, "snapshot_count")
+		assert.Contains(t, iostatReportData, "unique_devices")
+		assert.Contains(t, iostatReportData, "peak_cpu_usage")
+		assert.Contains(t, iostatReportData, "peak_device_queue_size")
+		assert.Contains(t, iostatReportData, "system_info")
+
+		// Verify HTML report contains expected elements
+		htmlReport := iostatReportData["html_report"].(string)
+		assert.Contains(t, htmlReport, "echarts.min.js")
+		assert.Contains(t, htmlReport, "CPU Utilization Over Time")
+		assert.Contains(t, htmlReport, "Device I/O Throughput Over Time")
+		assert.Contains(t, htmlReport, "Device I/O Await Times")
+		assert.Contains(t, htmlReport, "Device Average Queue Size")
+		assert.Contains(t, htmlReport, "Device I/O Requests Per Second")
+		assert.Contains(t, htmlReport, "Device I/O Request Sizes")
+
+		// Verify device utilization chart is NOT present
+		assert.NotContains(t, htmlReport, "Device Utilization Over Time")
 	})
 
 	t.Run("Report generation with special characters", func(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -92,8 +92,22 @@ var SampleFiles = map[string]TestFile{
 		FileType: "ttop",
 	},
 	"iostat": {
-		Name:     "iostat.txt",
-		Content:  []byte("Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util\nsda               0.00     0.00    0.00    0.00     0.00     0.00     0.00     0.00    0.00    0.00    0.00   0.00   0.00\n"),
+		Name: "iostat.txt",
+		Content: []byte(`Linux 5.10.0-32-cloud-amd64 (test-system) 	09/04/24 	_x86_64_	(4 CPU)
+
+09/04/24 12:07:20
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.36    0.00    0.40    0.04    0.01   97.20
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              2.08     94.38     0.31  13.07    0.89    45.47    9.58    210.39     5.55  36.68    2.74    21.96    0.09    377.20     0.00   0.00    0.95  4151.86    3.94    0.06    0.03   1.39
+
+09/04/24 12:07:21
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+          33.91    0.00    7.67    2.72    0.00   55.69
+
+Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
+sda              0.00      0.00     0.00   0.00    0.00     0.00  395.00  38116.00   133.00  25.19    8.65    96.50    1.00      4.00     0.00   0.00    1.00     4.00  122.00    0.06    3.42  39.20`),
 		FileType: "iostat",
 	},
 	"queries_json": {


### PR DESCRIPTION
- Add IOStatParser with robust parsing of iostat output format
- Add IOStatReporter with interactive HTML reports using ECharts
- Implement 6 comprehensive charts:
  * CPU Utilization Over Time
  * Device I/O Throughput Over Time
  * Device I/O Await Times (per device)
  * Device Average Queue Size (per device)
  * Device I/O Requests Per Second (per device)
  * Device I/O Request Sizes (per device)
- Replace device utilization metric with peak queue size (more meaningful for SSDs)
- Add strict validation with line number error reporting
- Include comprehensive unit and integration tests
- Wire up IOStat components in reporters.go
- Remove performance interpretation guide (not useful)
- Focus on actionable metrics for modern storage analysis